### PR TITLE
Add warn and error headers for two source positions, start and end

### DIFF
--- a/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Finding.java
+++ b/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Finding.java
@@ -53,6 +53,7 @@ public class Finding {
     this.type = type;
     this.msg = msg;
     this.sourcePosition = Optional.ofNullable(sourcePosition);
+    this.sourcePositionEnd = Optional.empty();
   }
 
   /**
@@ -80,6 +81,7 @@ public class Finding {
     this.type = type;
     this.msg = msg;
     this.sourcePosition = Optional.empty();
+    this.sourcePosition = Optional.empty();
   }
   
   /**
@@ -102,7 +104,14 @@ public class Finding {
   public Optional<SourcePosition> getSourcePosition() {
     return this.sourcePosition;
   }
-  
+
+  /**
+   * @return sourcePositionEnd
+   */
+  public Optional<SourcePosition> getSourcePositionEnd() {
+    return this.sourcePositionEnd;
+  }
+
   /**
    * @param sourcePosition the sourcePosition to set
    */

--- a/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Finding.java
+++ b/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Finding.java
@@ -40,7 +40,8 @@ public class Finding {
   private String msg;
   
   private Optional<SourcePosition> sourcePosition;
-  
+  private Optional<SourcePosition> sourcePositionEnd;
+
   /**
    * Constructor for de.se_rwth.commons.logging.Finding
    * 
@@ -52,6 +53,21 @@ public class Finding {
     this.type = type;
     this.msg = msg;
     this.sourcePosition = Optional.ofNullable(sourcePosition);
+  }
+
+  /**
+   * Constructor for de.se_rwth.commons.logging.Finding
+   *
+   * @param type
+   * @param msg
+   * @param start
+   * @param end
+   */
+  public Finding(Finding.Type type, String msg, SourcePosition start, SourcePosition end) {
+    this.type = type;
+    this.msg = msg;
+    this.sourcePosition = Optional.ofNullable(start);
+    this.sourcePositionEnd = Optional.ofNullable(end);
   }
   
   /**
@@ -174,6 +190,10 @@ public class Finding {
   public static Finding error(String message, SourcePosition sourcePosition) {
     return new Finding(Type.ERROR, message, sourcePosition);
   }
+
+  public static Finding error(String message, SourcePosition start, SourcePosition end) {
+    return new Finding(Type.ERROR, message, start, end);
+  }
   
   public static Finding warning(String message) {
     return new Finding(Type.WARNING, message);
@@ -181,6 +201,10 @@ public class Finding {
   
   public static Finding warning(String message, SourcePosition sourcePosition) {
     return new Finding(Type.WARNING, message, sourcePosition);
+  }
+
+  public static Finding warning(String message, SourcePosition start, SourcePosition end) {
+    return new Finding(Type.WARNING, message, start, end);
   }
   
 }

--- a/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Finding.java
+++ b/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Finding.java
@@ -81,7 +81,7 @@ public class Finding {
     this.type = type;
     this.msg = msg;
     this.sourcePosition = Optional.empty();
-    this.sourcePosition = Optional.empty();
+    this.sourcePositionEnd = Optional.empty();
   }
   
   /**

--- a/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Log.java
+++ b/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Log.java
@@ -334,7 +334,28 @@ public class Log {
     addFinding(warn);
     doPrint("[WARN]  " + warn.toString());
   }
-  
+
+  /**
+   * Log with level WARN and source position.
+   *
+   * @param msg the error message
+   * @param start the start position in a model file which caused the warning
+   * @param end the end position in a model file which caused the warning
+   */
+  public static final void warn(String msg, SourcePosition start, SourcePosition end) {
+    getLog().doWarn(msg, start, end);
+  }
+
+  /**
+   * Log with level ERROR and source position for start and end.
+   */
+  protected void doWarn(String msg, SourcePosition start, SourcePosition end) {
+    Finding warn = Finding.warning(msg, start, end);
+    addFinding(warn);
+    doErrPrint("[WARN] " + warn.toString());
+    terminateIfErrors();
+  }
+
   /**
    * Log with level WARN.
    * 
@@ -389,6 +410,27 @@ public class Log {
    */
   protected void doError(String msg, SourcePosition pos) {
     Finding error = Finding.error(msg, pos);
+    addFinding(error);
+    doErrPrint("[ERROR] " + error.toString());
+    terminateIfErrors();
+  }
+
+  /**
+   * Log with level ERROR and source position.
+   *
+   * @param msg the error message
+   * @param start the start position in a model file which caused the error
+   * @param end the end position in a model file which caused the error
+   */
+  public static final void error(String msg, SourcePosition start, SourcePosition end) {
+    getLog().doError(msg, start, end);
+  }
+
+  /**
+   * Log with level ERROR and source position for start and end.
+   */
+  protected void doError(String msg, SourcePosition start, SourcePosition end) {
+    Finding error = Finding.error(msg, start, end);
     addFinding(error);
     doErrPrint("[ERROR] " + error.toString());
     terminateIfErrors();


### PR DESCRIPTION
@maritabreuer 
This adds method headers for Log.warn and Log.error to accept two source positions. One for the start and one for the end of an error. This is needed for our online-ide, where we want to hint the Findings.