### PR TITLE
Add RichConsoleLogHook

### DIFF
--- a/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Finding.java
+++ b/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Finding.java
@@ -75,11 +75,27 @@ public class Finding {
    */
   public String buildMsg() {
     if (this.sourcePositionEnd.isPresent() && this.sourcePosition.isPresent()) {
-      return String.format(FORMAT_WITH_TWO_SOURCE_POSITIONS, this.sourcePosition.get(), this.sourcePositionEnd.get(), this.msg);
+      return String.format(FORMAT_WITH_TWO_SOURCE_POSITIONS, this.sourcePosition.get().toString(), this.sourcePositionEnd.get().toString(), this.msg);
     } else if (this.sourcePosition.isPresent()) {
-      return String.format(FORMAT_WITH_SOURCE_POSITION, this.sourcePosition.get(), this.msg);
+      return String.format(FORMAT_WITH_SOURCE_POSITION, this.sourcePosition.get().toString(), this.msg);
     }
     else {
+      return this.msg;
+    }
+  }
+
+  /**
+   * Formats the message in the GNU format.
+   * See <a href="https://www.gnu.org/prep/standards/html_node/Errors.html">GNU reference</a> for more information.
+   *
+   * @return the formatted message
+   */
+  public String buildMsgGNU() {
+    if (this.sourcePositionEnd.isPresent() && this.sourcePosition.isPresent()) {
+      return String.format(FORMAT_WITH_TWO_SOURCE_POSITIONS, this.sourcePosition.get().toStringFullPath(), this.sourcePositionEnd.get().getLine() + ":" + this.sourcePositionEnd.get().getColumn(), this.msg);
+    } else if (this.sourcePosition.isPresent()) {
+      return String.format(FORMAT_WITH_SOURCE_POSITION, this.sourcePosition.get().toStringFullPath(), this.msg);
+    } else {
       return this.msg;
     }
   }

--- a/se-commons-logging/src/main/java/de/se_rwth/commons/logging/ILogHook.java
+++ b/se-commons-logging/src/main/java/de/se_rwth/commons/logging/ILogHook.java
@@ -45,7 +45,7 @@ public interface ILogHook {
   }
 
   default void doInfo(String msg, String logName) {
-    doPrintln(String.format("[INFO]  %s %s", logName, msg));
+    doPrintln(formatInfo(msg, logName));
   }
 
   default void doInfo(String msg, Throwable t, String logName) {
@@ -53,31 +53,47 @@ public interface ILogHook {
     doPrintStackTrace(t);
   }
 
+  default String formatInfo(String msg, String logName) {
+    return String.format("[INFO]  %s %s", logName, msg);
+  }
+
   default void doWarn(Finding warn) {
-    doPrintln(String.format("[WARN]  %s", warn));
+    doPrintln(formatWarn(warn));
   }
 
   default void doWarn(Finding warn, Throwable t) {
-    doPrintln(String.format("[WARN]  %s", warn));
+    doPrintln(formatWarn(warn));
     doPrintStackTrace(t);
   }
 
+  default String formatWarn(Finding warn) {
+    return String.format("[WARN]  %s", warn);
+  }
+
   default void doError(Finding error) {
-    doPrintln(String.format("[ERROR]  %s", error));
+    doPrintln(formatError(error));
   }
 
   default void doError(Finding error, Throwable t) {
-    doPrintln(String.format("[ERROR]  %s", error));
+    doPrintln(formatError(error));
     doErrPrintStackTrace(t);
+  }
+
+  default String formatError(Finding error) {
+    return String.format("[ERROR]  %s", error);
   }
 
   default void doErrorUser(Finding error) {
-    doPrintln(String.format("[USER-ERROR]  %s", error));
+    doPrintln(formatErrorUser(error));
   }
 
   default void doErrorUser(Finding error, Throwable t) {
-    doPrintln(String.format("[USER-ERROR]  %s", error));
+    doPrintln(formatErrorUser(error));
     doErrPrintStackTrace(t);
+  }
+
+  default String formatErrorUser(Finding error) {
+    return String.format("[USER-ERROR]  %s", error);
   }
 
   void doPrintln(String msg);

--- a/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Log.java
+++ b/se-commons-logging/src/main/java/de/se_rwth/commons/logging/Log.java
@@ -1052,6 +1052,10 @@ public class Log {
     getLog().logHooks.remove(hook);
   }
 
+  public static void clearLogHooks() {
+    getLog().logHooks.clear();
+  }
+
   public static void setErrorHook(IErrorHook hook) {
     getLog().errorHook = hook;
   }

--- a/se-commons-logging/src/main/java/de/se_rwth/commons/logging/RichConsoleLogHook.java
+++ b/se-commons-logging/src/main/java/de/se_rwth/commons/logging/RichConsoleLogHook.java
@@ -1,0 +1,34 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.se_rwth.commons.logging;
+
+/**
+ * A logger that supports rich console output, including colors and hyperlinks to files.
+ */
+public class RichConsoleLogHook extends ConsoleLogHook {
+
+  public static final String RESET = "\033[0m";
+  public static final String BLUE = "\033[0;34m";
+  public static final String YELLOW = "\033[0;33m";
+  public static final String RED = "\033[0;31m";
+  public static final String RED_BOLD = "\033[1;31m";
+
+  @Override
+  public String formatInfo(String msg, String logName) {
+    return String.format("%s[INFO]%s  %s %s", BLUE, RESET, logName, msg);
+  }
+
+  @Override
+  public String formatWarn(Finding warn) {
+    return String.format("%s[WARN]%s  %s", YELLOW, RESET, warn.buildMsgGNU());
+  }
+
+  @Override
+  public String formatError(Finding error) {
+    return String.format("%s[ERROR]%s  %s", RED_BOLD, RESET, error.buildMsgGNU());
+  }
+
+  @Override
+  public String formatErrorUser(Finding error) {
+    return String.format("%s[USER-ERROR]%s  %s", RED, RESET, error.buildMsgGNU());
+  }
+}

--- a/se-commons-utilities/src/main/java/de/se_rwth/commons/SourcePosition.java
+++ b/se-commons-utilities/src/main/java/de/se_rwth/commons/SourcePosition.java
@@ -12,7 +12,7 @@ import java.util.Optional;
  *
  */
 public final class SourcePosition implements Comparable<SourcePosition>, Cloneable {
-  
+
   /* A default source position at line 0 and column 0. */
   static SourcePosition defaultPosition = new SourcePosition(0, 0);
   
@@ -54,9 +54,7 @@ public final class SourcePosition implements Comparable<SourcePosition>, Cloneab
   
   /**
    * Constructor for mc.ast.SourcePosition
-   * 
-   * @param line
-   * @param column
+   *
    * @param fileName
    */
   public SourcePosition(String fileName) {
@@ -160,6 +158,17 @@ public final class SourcePosition implements Comparable<SourcePosition>, Cloneab
     return (this.fileName.isPresent() ? FilenameUtils.getName(this.fileName.get()) + ":" : "")
         + "<" + this.line + ","
         + this.column + ">";
+  }
+
+  /**
+   * The String representation of this source position of the form:
+   * <code>"filepath:a:b"</code> where <code>"a"</code> denotes the line component
+   * and <code>"b"</code> denotes the column component.
+   *
+   */
+  public String toStringFullPath() {
+    return (this.fileName.isPresent() ? this.fileName.get() : "")
+      + ":" + this.line + ":" + this.column;
   }
   
   @Override


### PR DESCRIPTION
Adds a RichConsoleLogHook that:
- Adds colors to the error messages
- Prints out the full path of source positions (following GNU guidelines) such that they are clickable in IDEs