### PR TITLE
Cached Isolation WorkQueue

### DIFF
--- a/se-commons-gradle/build.gradle
+++ b/se-commons-gradle/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 }
 tasks.named('test', Test) {
   useJUnitPlatform()
+  // Parallel test execution
+  systemProperty("junit.jupiter.execution.parallel.enabled", true)
+  systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
 }
 
 gradlePlugin {

--- a/se-commons-gradle/build.gradle
+++ b/se-commons-gradle/build.gradle
@@ -1,11 +1,16 @@
 /* (c) https://github.com/MontiCore/monticore */
 
+plugins {
+  id 'java-gradle-plugin' // No plugin will be published, but for tests
+}
+
 description = 'se-commons: gradle'
 
 dependencies {
   implementation gradleApi()
   implementation project(":se-commons-utilities")
   implementation project(":se-commons-logging")
+  implementation 'com.google.code.gson:gson:2.13.2'
 
   implementation "org.apache.commons:commons-lang3:3.8.1"
   implementation "com.google.guava:guava:33.1.0-jre"
@@ -17,4 +22,40 @@ publishing {
       from(components.java)
     }
   }
+}
+
+// Test our plugin infrastructure with a test-plugin
+sourceSets {
+  testPlugin {
+    compileClasspath += sourceSets.main.output
+    runtimeClasspath += sourceSets.main.output
+  }
+}
+configurations {
+  testPluginImplementation.extendsFrom implementation
+  testPluginRuntimeOnly.extendsFrom runtimeOnly
+}
+
+dependencies {
+  testPluginImplementation gradleApi()
+  testImplementation gradleTestKit()
+  testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
+  testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+tasks.named('test', Test) {
+  useJUnitPlatform()
+}
+
+gradlePlugin {
+  testSourceSet sourceSets.test
+}
+
+tasks.register('testPluginJar', Jar) {
+  archiveClassifier = 'testPlugin'
+  from sourceSets.testPlugin.output
+}
+
+tasks.pluginUnderTestMetadata {
+  pluginClasspath.from(tasks.testPluginJar)
 }

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
@@ -476,5 +476,23 @@ public abstract class CommonMCTask extends DefaultTask {
       add.accept(f);
     }
   }
+  
+  /**
+   * Turn a path into string accepted by {@link File#File(String)}.
+   * This especially contains spaces
+   *
+   * @param path the path
+   * @return a valid argument for File
+   */
+  protected String pathToFileString(Path path) {
+    return path.toFile().getAbsolutePath();
+  }
+  
+  protected String pathToHumanReadableString(Path path, Path projectWorkingDir) {
+    if (projectWorkingDir.getRoot().equals(path.getRoot())) {
+      return projectWorkingDir.relativize(path).toString();
+    }
+    return pathToFileString(path);
+  }
 
 }

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
@@ -156,7 +156,7 @@ public abstract class CommonMCTask extends DefaultTask {
   @Incremental  // Incremental symbol path (such as MC generation the modelpath)
   @Optional
   // Absolute, since this can contain elements from the gradle jar cache, outside the project
-  @PathSensitive(PathSensitivity.ABSOLUTE) // TODO: really absolute?
+  @Classpath // The content of the jar file is normalized so that time stamps and order of the zip entries in the jar file do not matter
   public abstract ConfigurableFileCollection getIncrementalSymbolPath();
 
 

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -386,17 +387,33 @@ public abstract class CommonMCTask extends DefaultTask {
       workQueue.submit(getToolAction(), param -> {
         param.getArgs().set(args);
         param.getProgressName().set(progressName);
+        param.getPrefix().set("[" + progressName + "]");
+        // A unique name for the stats reporter, etc.
+        int classPathHash = getExtraClasspathElements().getFiles().stream().map(File::getName).collect(Collectors.joining(",")).hashCode();
+        param.getStatsUniqueName().set( "[" + getPath() + "(" + getClass().getSimpleName() + ")"
+                + "[" + classPathHash + "]"
+                + "#" + progressName + "]");
         param.getExtraClasspathElements().setFrom(this.getExtraClasspathElements());
         param.getProgressLogger().set(getProgressLoggerService());
+        this.specParam(param);
       });
     }
+  }
+
+  /**
+   * Customize the tool parameters
+   * @param param the params being constructed
+   */
+  protected void specParam(ToolArgActionParameter param) {
+    // noop
   }
 
   @Internal
   public abstract Property<ProgressLoggerService> getProgressLoggerService();
 
-  @Internal
-  protected abstract Consumer<String[]> getRunMethod();
+  protected Consumer<String[]> getRunMethod() {
+    throw new IllegalStateException("No tool invoker present, workQueueDebug is not supported!");
+  }
 
   @Internal
   protected abstract Class<? extends AToolAction> getToolAction();

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
@@ -97,13 +97,11 @@ public abstract class CommonMCTask extends DefaultTask {
 
 
   @Deprecated // old-school hwcDir = ..
-  @Internal
   public void setHwcDir(File f){
     this.getHandWrittenCodeDir().setFrom(f);
   }
 
   @Deprecated // old-school hwcDir = [...] / hwcDir +=
-  @Internal
   public void setHwcDir(Iterable<File> f){
     this.getHandWrittenCodeDir().setFrom(f);
   }
@@ -115,13 +113,11 @@ public abstract class CommonMCTask extends DefaultTask {
   }
 
   @Deprecated
-  @Internal
   public void setHwgDir(File f){
     this.getHandWrittenGrammarDir().setFrom(f);
   }
 
   @Deprecated
-  @Internal
   public void setHwgDir(Iterable<File> f){
     this.getHandWrittenGrammarDir().setFrom(f);
   }
@@ -411,6 +407,7 @@ public abstract class CommonMCTask extends DefaultTask {
   @Internal
   public abstract Property<ProgressLoggerService> getProgressLoggerService();
 
+  @Internal
   protected Consumer<String[]> getRunMethod() {
     throw new IllegalStateException("No tool invoker present, workQueueDebug is not supported!");
   }

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/MCAllFilesTask.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/MCAllFilesTask.java
@@ -66,11 +66,10 @@ public abstract class MCAllFilesTask extends CommonMCTask {
 
       Path cwd = getProject().getProjectDir().toPath().toAbsolutePath();
       getLogger().debug("Starting Tool with args: \n{} for {}",
-              String.join(" ", createArgList(p -> "." + File.separator +
-                      (cwd.getRoot().equals(p.getRoot()) ? cwd.relativize(p) : p.toAbsolutePath()))),
-              this.getName());
+          String.join(" ", createArgList(p -> this.pathToHumanReadableString(p, cwd))),
+          this.getName());
 
-      List<String> args = createArgList(p -> p.toAbsolutePath().toString());
+      List<String> args = createArgList(this::pathToFileString);
       startGeneration(args, this.getName());
     } else {
       getLogger().info("UP-TO-DATE, no action required");

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/MCSingleFileTask.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/MCSingleFileTask.java
@@ -67,11 +67,10 @@ abstract public class MCSingleFileTask extends CommonMCTask {
   private void startGeneration(File f) {
     Path cwd = getProject().getProjectDir().toPath().toAbsolutePath();
     getLogger().debug("Starting Tool: \n{} for {}",
-            String.join(" ", createArgList(f.toPath(), p -> "." + File.separator +
-            (cwd.getRoot().equals(p.getRoot()) ? cwd.relativize(p) : p.toAbsolutePath()))),
-            this.getName());
+        String.join(" ", createArgList(f.toPath(), p -> pathToHumanReadableString(p, cwd))),
+        this.getName());
 
-    List<String> args = this.createArgList(f.toPath(), p -> p.toAbsolutePath().toString());
+    List<String> args = this.createArgList(f.toPath(), this::pathToFileString);
     startGeneration(args, f.getName());
   }
 

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/ToolArgActionParameter.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/ToolArgActionParameter.java
@@ -2,15 +2,15 @@
 package de.monticore.gradle.common;
 
 import de.monticore.gradle.internal.ProgressLoggerService;
+import de.monticore.gradle.queue.CachedIsolatedWorkQueue;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.workers.WorkParameters;
 
 /**
  * work parameters consisting of CLI arguments
  */
-public interface ToolArgActionParameter extends WorkParameters {
+public interface ToolArgActionParameter extends CachedIsolatedWorkQueue.WorkQueueParameters {
     /**
      * Arguments passed to a Tool
      */
@@ -19,6 +19,7 @@ public interface ToolArgActionParameter extends WorkParameters {
     /**
      * Name of this work action, passed to the log
      */
+    @Deprecated
     Property<String> getProgressName();
 
     /**

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/internal/isolation/CachedIsolation.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/internal/isolation/CachedIsolation.java
@@ -1,9 +1,12 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.gradle.internal.isolation;
 
+import com.google.common.collect.Sets;
 import de.monticore.gradle.internal.io.PrefixStream;
 import de.monticore.gradle.internal.io.PrintStreamThreadProxy;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -27,12 +30,18 @@ import java.util.stream.Stream;
 public class CachedIsolation<T> {
 
   protected final List<IIsolationData<T>> internalRunners = Collections.synchronizedList(new LinkedList<>());
+  protected final Logger logger = Logging.getLogger(CachedIsolation.class);
+
+  /**
+   * Time (in ms) in which the close threshold timer is checked
+   */
+  protected final long closeThresholdTimer = 2 * 1000; // 6 seconds by default
 
   /**
    * Time (in ms) after the last use of an isolated classloader before its
    * allocated resources are freed
    */
-  protected final long closeThreshold = 6 * 1000; // 6 seconds
+  protected long closeThreshold = 6 * 1000; // 6 seconds by default
 
   /**
    * We periodically clean up the open classloaders
@@ -57,10 +66,20 @@ public class CachedIsolation<T> {
   protected int staggerCount;
 
   /**
+   * The threshold to use to check for unused classloaders
+   * @param closeThreshold the new threshold
+   */
+  public void setCloseThreshold(long closeThreshold) {
+    logger.debug("Setting close threshold to {} ", closeThreshold );
+    this.closeThreshold = closeThreshold;
+  }
+
+  /**
    *
    * @param staggeredStartUpFixedDelay the (fixed) time between the first and all further runners
    * @param staggeredStartUpDelayPerRunner the time between the startup of individual runners
    */
+  @Deprecated
   public void setStaggeredStartupParams(int staggeredStartUpFixedDelay, int staggeredStartUpDelayPerRunner) {
     this.staggeredStartUpFixedDelay = staggeredStartUpFixedDelay;
     this.staggeredStartUpDelayPerRunner = staggeredStartUpDelayPerRunner;
@@ -72,9 +91,17 @@ public class CachedIsolation<T> {
     cleanupTimer.schedule(new TimerTask() {
       @Override
       public void run() {
-        CachedIsolation.this.cleanupOld();
+        CachedIsolation.this.cleanupOld(closeThreshold);
       }
-    }, closeThreshold, closeThreshold);
+    }, closeThresholdTimer, closeThresholdTimer);
+  }
+
+  /**
+   * Mark all internal runers as ready to be unloaded
+   */
+  public void markForErasure() {
+    logger.debug("Marking forErasure");
+    this.internalRunners.forEach(r -> ((IsolationData<?>)r).lastRun = 0);
   }
 
   /**
@@ -88,14 +115,16 @@ public class CachedIsolation<T> {
             .filter(x -> predicate.test(x.getExtraData()))
             .findAny();
     if (d.isPresent()) {
+      logger.debug("Reusing existing runner " + d.get().getUUID());
       d.get().setRunning(true);
       return d.get();
     }
-    this.cleanupOld();
+    this.cleanupOld(closeThreshold);
     final long staggerWait = getWaitForStaggeredStartup();
     this.lastStartup = System.currentTimeMillis();
     if (staggerWait <= 0) {
       IsolationData<T> data = new IsolationData<>();
+      logger.debug("Creating new loader " + data.getUUID());
       data.classLoader = getClassLoader((URLClassLoader) Thread.currentThread().getContextClassLoader(), supplier);
       data.running = true;
       data.extraData = supplier.get();
@@ -142,7 +171,7 @@ public class CachedIsolation<T> {
    * (and thus are not isolated)
    */
   protected Set<String> getPassThroughPackages() {
-    return Set.of("org.gradle");
+    return Sets.newHashSet("org.gradle");
   }
 
   protected ClassLoader getClassLoader(URLClassLoader contextClassLoader, Supplier<T> supplier) {
@@ -297,16 +326,26 @@ public class CachedIsolation<T> {
     ps.setRedirect(new PrefixStream(ps.getOriginal(), prefix));
   }
 
+  /**
+   * Cleanup all (unused) class loaders
+   */
+  public void cleanupAll() {
+    this.cleanupOld(0);
+  }
 
   /**
    * Close unused classloaders to free up memory
+   * @param pCloseThreshold the threshold to use
    */
-  protected synchronized void cleanupOld() {
-    long threshold = System.currentTimeMillis() - this.closeThreshold;
+  protected synchronized void cleanupOld(long pCloseThreshold) {
+    long threshold = System.currentTimeMillis() - pCloseThreshold;
     Iterator<IIsolationData<T>> isolated = this.internalRunners.iterator();
+    logger.debug("Running cleanup thread");
     while (isolated.hasNext()) {
       IIsolationData<T> data = isolated.next();
+      logger.debug(" - {} - {} - {}", data.isRunning() ? "R" : "I", data.getLastRun(), data.getUUID());
       if (!data.isRunning() && data.getLastRun() < threshold){
+        logger.debug("   - close ");
         if (data.getClassLoader() instanceof Closeable) {
           // Close closeable classloaders
           try {
@@ -331,6 +370,8 @@ public class CachedIsolation<T> {
     protected long lastRun = System.currentTimeMillis();
 
     protected T extraData;
+
+    protected final UUID uuid = UUID.randomUUID();
 
     @Override
     public ClassLoader getClassLoader() {
@@ -368,8 +409,14 @@ public class CachedIsolation<T> {
       this.running = false;
       this.lastRun = System.currentTimeMillis();
     }
+
+    @Override
+    public UUID getUUID() {
+      return this.uuid;
+    }
   }
 
+  @Deprecated
   protected static class StaggeredIsolationData<T> implements IIsolationData<T> {
     protected Optional<IIsolationData<T>> actual = Optional.empty();
     protected final Supplier<IIsolationData<T>> supplier;
@@ -419,6 +466,11 @@ public class CachedIsolation<T> {
     public void close() {
       getActual().close();
     }
+
+    @Override
+    public UUID getUUID() {
+      return getActual().getUUID();
+    }
   }
 
   protected interface IIsolationData<T> extends AutoCloseable {
@@ -436,6 +488,8 @@ public class CachedIsolation<T> {
 
     @Override
     void close();
+
+    UUID getUUID();
   }
 
   /**

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/internal/isolation/CachedIsolation.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/internal/isolation/CachedIsolation.java
@@ -23,10 +23,12 @@ import java.util.stream.Stream;
 
 /**
  * A class which allows safe, concurrent execution of work units
- *  using reuseabe, isolated classloaders.
+ *  using re-useabe, isolated classloaders.
+ * @deprecated consider using the {@link de.monticore.gradle.queue.CachedIsolatedWorkQueue}
  * @param <T> an optional object associated with an isolated classloader,
  *            used to determine reusability
  */
+@Deprecated
 public class CachedIsolation<T> {
 
   protected final List<IIsolationData<T>> internalRunners = Collections.synchronizedList(new LinkedList<>());

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedIsolatedWorkQueue.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedIsolatedWorkQueue.java
@@ -1,0 +1,97 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.gradle.queue;
+
+import org.gradle.api.Action;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkQueue;
+import org.gradle.workers.WorkerExecutionException;
+
+import java.util.UUID;
+
+/**
+ * {@link WorkQueue} implementation using an isolated classloader,
+ * but re-using these.
+ * <p>
+ * Retrieve a new instance using the {@link CachedQueueService}
+ */
+public class CachedIsolatedWorkQueue implements WorkQueue {
+
+  protected final WorkQueue backingQueue;
+
+  protected final Provider<CachedQueueService> cachedQueueService;
+
+  protected final InstantiatorFactory instantiatorFactory;
+  protected final ServiceRegistry serviceRegistry;
+
+  protected final FileCollection classpath;
+
+  protected CachedIsolatedWorkQueue(WorkQueue backingQueue, InstantiatorFactory instantiatorFactory,
+                                    ServiceRegistry services,
+                                    Provider<CachedQueueService> cachedQueueService,
+                                    FileCollection classpath) {
+    this.backingQueue = backingQueue;
+    this.cachedQueueService = cachedQueueService;
+
+    this.serviceRegistry = services;
+    this.instantiatorFactory = instantiatorFactory;
+    this.classpath = classpath;
+  }
+
+  @Override
+  public <T extends WorkParameters> void submit(Class<? extends WorkAction<T>> workActionClass,
+                                                Action<? super T> parameterAction) {
+    final UUID uuid = UUID.randomUUID();
+
+    cachedQueueService.get().register(uuid, workActionClass, parameterAction, this.instantiatorFactory, this.serviceRegistry, classpath);
+    backingQueue.submit(WAction.class, _p -> {
+      _p.getUUID().set(uuid);
+      _p.getQueueService().set(cachedQueueService);
+    });
+  }
+
+  @Override
+  public void await() throws WorkerExecutionException {
+    this.backingQueue.await();
+  }
+
+
+  /**
+   * WorkAction for our backing queue
+   */
+  public static abstract class WAction implements WorkAction<WrappingParams> {
+
+    @Override
+    public void execute() {
+      try {
+        getParameters().getQueueService().get().doExecuteWorkAction(getParameters().getUUID().get());
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public interface WrappingParams extends WorkParameters {
+    Property<UUID> getUUID();
+
+    Property<CachedQueueService> getQueueService();
+  }
+
+  public interface WorkQueueParameters extends WorkParameters {
+
+    /**
+     * @return The prefix used for the logger
+     */
+    Property<String> getPrefix();
+
+    /**
+     * @return A unique name used for reporting
+     */
+    Property<String> getStatsUniqueName();
+  }
+}

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedIsolationStats.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedIsolationStats.java
@@ -1,0 +1,88 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.gradle.queue;
+
+
+import com.google.gson.Gson;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Statistics collector for the cached isolated worker.
+ *
+ */
+public class CachedIsolationStats {
+
+  protected List<Event> events = Collections.synchronizedList(new ArrayList<>());
+
+  void track(EventKind kind, @Nullable UUID uuid, int semaphoreMax, List<CachedQueueService.IIsolationData> runners) {
+    track(kind, uuid, semaphoreMax, runners, null);
+  }
+
+  void track(EventKind kind, @Nullable UUID uuid, int semaphoreMax, List<CachedQueueService.IIsolationData> runners, String reason) {
+    Event event = new Event();
+    event.systemInfo = new SystemInfo();
+    event.systemInfo.semaphoreMax = semaphoreMax;
+    event.kind = kind;
+    event.runner = uuid;
+    event.existingRunnerList = createRunnerList(runners);
+    event.reason = reason;
+    events.add(event);
+  }
+
+  public String asJson(Gson gson) {
+    return gson.toJson(new ArrayList<>(this.events));
+  }
+
+  protected List<ExistingRunner> createRunnerList(List<CachedQueueService.IIsolationData> runners) {
+    return runners.stream().map(r -> {
+      ExistingRunner existingRunner = new ExistingRunner();
+      existingRunner.lastRun = r.getLastRun();
+      existingRunner.uuid = r.getUUID();
+      existingRunner.running = r.isRunning();
+      return existingRunner;
+    }).collect(Collectors.toList());
+  }
+
+  // The following classes are serialized as json objects
+
+  @SuppressWarnings("unused")
+  protected static class Event {
+    long time = System.currentTimeMillis();
+    SystemInfo systemInfo;
+    EventKind kind;
+    List<ExistingRunner> existingRunnerList;
+    UUID runner;
+    String reason;
+  }
+
+  enum EventKind {
+    REUSE,
+    CREATE,
+    CLEANUP,
+    START,
+    DONE,
+    /**
+     * The project build is done
+     */
+    BUILT_DONE
+  }
+
+
+  @SuppressWarnings("unused")
+  protected static class SystemInfo {
+    final long freeMemory = Runtime.getRuntime().freeMemory();
+    final long totalMemory = Runtime.getRuntime().totalMemory();
+    final long maxMemory = Runtime.getRuntime().maxMemory();
+    final long availableProcessors = Runtime.getRuntime().availableProcessors();
+    int semaphoreMax;
+  }
+
+
+  protected static class ExistingRunner {
+    UUID uuid;
+    boolean running;
+    long lastRun;
+  }
+}

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedQueueService.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedQueueService.java
@@ -172,6 +172,7 @@ public abstract class CachedQueueService
     Optional<IIsolationData> d = this.internalRunners.stream().filter(x -> !x.isRunning())
             .filter(x -> predicate.test(x.getExtraData())).findAny();
     if (d.isPresent()) {
+      logger.debug("Reusing existing runner " + d.get().getUUID());
       d.get().setRunning(true);
       stats.track(CachedIsolationStats.EventKind.REUSE, d.get().getUUID(), maximumLoadersFromConfig, this.internalRunners, uniqueId);
       return d.get();
@@ -187,6 +188,7 @@ public abstract class CachedQueueService
     data.extraData = supplier.get();
     stats.track(CachedIsolationStats.EventKind.CREATE, data.getUUID(), maximumLoadersFromConfig, this.internalRunners, uniqueId);
     this.internalRunners.add(data);
+    logger.debug("Creating new loader " + data.getUUID());
     setupTimer();
     return data;
   }
@@ -205,6 +207,11 @@ public abstract class CachedQueueService
     }, 2 * 1000, 2 * 1000);
   }
 
+  public void setCloseThreshold(long closeThreshold) {
+    logger.debug("Setting close threshold to {} ", closeThreshold );
+    this.closeThreshold = closeThreshold;
+  }
+
   /**
    * Close unused classloaders to free up memory
    */
@@ -214,10 +221,13 @@ public abstract class CachedQueueService
 
     long threshold = System.currentTimeMillis() - pCloseThreshold;
     Iterator<IIsolationData> isolated = this.internalRunners.iterator();
+    logger.debug("Running cleanup thread");
     while (isolated.hasNext()) {
       IIsolationData data = isolated.next();
+      logger.debug(" - {} - {} - {}", data.isRunning() ? "R" : "I", data.getLastRun(), data.getUUID());
       if (!data.isRunning() && data.getLastRun() < threshold) {
         stats.track(CachedIsolationStats.EventKind.CLEANUP, data.getUUID(), maximumLoadersFromConfig, this.internalRunners);
+        logger.debug("   - close ");
         if (data.getClassLoader() instanceof Closeable) {
           // Close closeable classloaders
           try {

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedQueueService.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedQueueService.java
@@ -1,0 +1,641 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.gradle.queue;
+
+import com.google.gson.Gson;
+import de.monticore.gradle.internal.io.PrefixStream;
+import de.monticore.gradle.internal.io.PrintStreamThreadProxy;
+import de.monticore.gradle.internal.isolation.IsolatedURLClassLoader;
+import org.gradle.api.Action;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.api.services.BuildServiceRegistry;
+import org.gradle.execution.RunRootBuildWorkBuildOperationType;
+import org.gradle.internal.Cast;
+import org.gradle.internal.build.event.BuildEventListenerRegistryInternal;
+import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.isolated.IsolationScheme;
+import org.gradle.internal.isolation.Isolatable;
+import org.gradle.internal.isolation.IsolatableFactory;
+import org.gradle.internal.operations.*;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.serialize.InputStreamBackedDecoder;
+import org.gradle.internal.serialize.OutputStreamBackedEncoder;
+import org.gradle.internal.serialize.Serializer;
+import org.gradle.internal.service.ServiceLookup;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkQueue;
+import org.gradle.workers.WorkerExecutor;
+import org.gradle.workers.internal.ActionExecutionSpecFactory;
+import org.gradle.workers.internal.IsolatableSerializerRegistry;
+
+import javax.annotation.Nullable;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.*;
+import java.util.*;
+import java.util.concurrent.Semaphore;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Service managing the cached isolators and their backing queue
+ */
+public abstract class CachedQueueService
+        implements BuildService<BuildServiceParameters.None>, AutoCloseable, BuildOperationListener {
+
+  static CachedQueueService INSTANCE;
+
+  protected Logger logger = Logging.getLogger(CachedQueueService.class);
+
+  protected CachedIsolationStats stats = new CachedIsolationStats();
+
+
+  public void init(Gradle gradle) {
+    this.init(((GradleInternal) gradle).getServices());
+  }
+
+  protected void init(ServiceRegistry serviceRegistry) {
+    logger.debug("Initializing CachedQueueService");
+    if (INSTANCE == null) {
+      INSTANCE = this;
+    } else if (INSTANCE != this) {
+      logger.warn("Possibly overriding the CachedQueueService instance");
+      INSTANCE = this;
+    }
+    this.serviceRegistry = Objects.requireNonNull(serviceRegistry);
+    this.providerSelf = (Provider<CachedQueueService>) serviceRegistry.get(BuildServiceRegistry.class).getRegistrations().getByName(NAME).getService();
+    Objects.requireNonNull(serviceRegistry.get(ActionExecutionSpecFactory.class), "ActionExecutionSpecFactory");
+    Objects.requireNonNull(serviceRegistry.get(IsolatableFactory.class), "isolatableFactory");
+
+    serviceRegistry.get(BuildEventListenerRegistryInternal.class)
+            .onOperationCompletion(this.providerSelf);
+
+  }
+
+  /**
+   * Service name
+   */
+  public static final String NAME = "se_cached_queue_service";
+
+  /**
+   * Time (in ms) after the last use of an isolated classloader before its
+   * allocated resources are freed
+   */
+  protected long closeThreshold = 6 * 1000; // 6 seconds
+
+  /**
+   * We periodically clean up the open classloaders
+   * Closing classloaders frees up the resources from memory
+   */
+  protected Timer cleanupTimer;
+
+  protected final List<IIsolationData> internalRunners =
+          Collections.synchronizedList(new LinkedList<>());
+
+  /**
+   * Unfortunately, Gradle does not allow us to limit the maximum work-actions of a WorkQueue being
+   * performed
+   * (without limit the max-worker for the entire project)
+   */
+  protected final Semaphore semaphore;
+
+  protected int maximumLoadersFromConfig = 0;
+
+  // Empty array of ProtectionDomain - see the doPrivileged() part below
+  private static final ProtectionDomain[] NO_DOMAINS = new ProtectionDomain[0];
+
+  // AccessControlContext without domains - see the doPrivileged() part below
+  private static final AccessControlContext NO_DOMAINS_ACCESS_CONTROL_CONTEXT =
+          new AccessControlContext(NO_DOMAINS);
+
+  /**
+   * WorkParameters do not support the information stored in the {@link ActualTaskInfo},
+   * which is why we use this weird workaround of a UUID-key
+   */
+  protected Map<UUID, ActualTaskInfo<?>> taskInfoMap = new HashMap<>();
+
+  protected final IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme =
+          new IsolationScheme<>(Cast.uncheckedCast(WorkAction.class), WorkParameters.class,
+                  WorkParameters.None.class);
+
+  public CachedQueueService() {
+    this.maximumLoadersFromConfig = guessInitialMaxParallel();
+    logger.debug("Starting with a maximum count of {}", maximumLoadersFromConfig);
+    this.semaphore = new Semaphore(maximumLoadersFromConfig);
+  }
+
+  public synchronized void setMaxConcurrentMC(int maxParallelMC) {
+    if (maximumLoadersFromConfig < maxParallelMC) {
+      // The limit has been increased -> release/add some permits
+      semaphore.release(maxParallelMC - maximumLoadersFromConfig);
+      maximumLoadersFromConfig = maxParallelMC;
+    } else if (maximumLoadersFromConfig > maxParallelMC) {
+      // The max amount has been lowered -> acquire/remove some permits
+      semaphore.acquireUninterruptibly(maximumLoadersFromConfig - maxParallelMC);
+      maximumLoadersFromConfig = maxParallelMC;
+    }
+  }
+
+
+  protected ServiceRegistry serviceRegistry;
+  protected Provider<CachedQueueService> providerSelf;
+
+  @Override
+  public void close() throws Exception {
+    this.markForErasure();
+    this.cleanupOld(0);
+  }
+
+
+  /**
+   * Get a new (auto-closing) isolated class loader.
+   * In case no available class loaders are present,
+   * a new instance may be created.
+   */
+  protected synchronized IIsolationData getLoader(Predicate<FileCollection> predicate,
+                                                  Supplier<FileCollection> supplier,
+                                                  String uniqueId) {
+    Optional<IIsolationData> d = this.internalRunners.stream().filter(x -> !x.isRunning())
+            .filter(x -> predicate.test(x.getExtraData())).findAny();
+    if (d.isPresent()) {
+      d.get().setRunning(true);
+      stats.track(CachedIsolationStats.EventKind.REUSE, d.get().getUUID(), maximumLoadersFromConfig, this.internalRunners, uniqueId);
+      return d.get();
+    }
+
+    // TODO/Future work: Check, if we have enough memory to warrant starting a new loader or should better wait a bit
+
+    this.cleanupOld(closeThreshold);
+    IsolationData data = new IsolationData();
+    data.classLoader =
+            getClassLoader((URLClassLoader) Thread.currentThread().getContextClassLoader(), supplier);
+    data.running = true;
+    data.extraData = supplier.get();
+    stats.track(CachedIsolationStats.EventKind.CREATE, data.getUUID(), maximumLoadersFromConfig, this.internalRunners, uniqueId);
+    this.internalRunners.add(data);
+    setupTimer();
+    return data;
+  }
+
+  protected synchronized void setupTimer() {
+    if (cleanupTimer != null) {
+      return;
+    }
+    cleanupTimer = new Timer();
+    cleanupTimer.schedule(new TimerTask() {
+
+      @Override
+      public void run() {
+        CachedQueueService.this.cleanupOld(closeThreshold);
+      }
+    }, 2 * 1000, 2 * 1000);
+  }
+
+  /**
+   * Close unused classloaders to free up memory
+   */
+  protected synchronized void cleanupOld(long pCloseThreshold) {
+    // TODO/Future work: We could use the buildListener and currently pending to guess-estimate,
+    // whether we still need to run a task with this classloader
+
+    long threshold = System.currentTimeMillis() - pCloseThreshold;
+    Iterator<IIsolationData> isolated = this.internalRunners.iterator();
+    while (isolated.hasNext()) {
+      IIsolationData data = isolated.next();
+      if (!data.isRunning() && data.getLastRun() < threshold) {
+        stats.track(CachedIsolationStats.EventKind.CLEANUP, data.getUUID(), maximumLoadersFromConfig, this.internalRunners);
+        if (data.getClassLoader() instanceof Closeable) {
+          // Close closeable classloaders
+          try {
+            ((Closeable) data.getClassLoader()).close();
+          } catch (IOException ignored) {
+          }
+        }
+        data.cleanUp();
+        isolated.remove();
+      }
+    }
+    if (cleanupTimer != null && this.internalRunners.isEmpty()) {
+      cleanupTimer.cancel();
+      cleanupTimer = null;
+    }
+  }
+
+  protected ClassLoader getClassLoader(URLClassLoader contextClassLoader,
+                                       Supplier<FileCollection> supplier) {
+    // Merge the extra classpath with the current classpath
+    URL[] urls = Stream.concat(supplier.get().getFiles().stream().map(f -> {
+      try {
+        return f.toURI().toURL();
+      } catch (MalformedURLException e) {
+        throw new RuntimeException(e.getMessage(), e);
+      }
+    }), Arrays.stream(contextClassLoader.getURLs())).toArray(URL[]::new);
+    return new IsolatedURLClassLoader(urls, contextClassLoader, getPassThroughPackages());
+  }
+
+  /**
+   * @return a set of packages which may be loaded from the context classloader
+   * (and thus are not isolated)
+   */
+  protected Set<String> getPassThroughPackages() {
+    return Set.of("org.gradle");
+  }
+
+  public void doExecuteWorkAction(UUID actionUUID) {
+    try {
+      // In case we run into the limit of maximum concurrent MontiCore Generation actions,
+      // we wait until another generation has concluded
+      semaphore.acquire();
+    } catch (InterruptedException e) {
+      // Unable to acquire slot to run -> abort
+      throw new RuntimeException(e);
+    }
+    try {
+      doExecuteWorkAction(taskInfoMap.get(actionUUID));
+    } finally {
+      semaphore.release();
+    }
+  }
+
+  void doExecuteWorkAction(ActualTaskInfo<?> info) {
+
+    Class<? extends WorkParameters> parameterTypeNotIsolated =
+            isolationScheme.parameterTypeFor(info.workActionClass);
+
+    // Unsafe, as they are still in the wrong classloader
+    WorkParameters parametersUnsafe = parameterTypeNotIsolated == null ? null
+            : info.instantiatorFactory.decorateLenient(
+                    info.services)
+            .newInstance(parameterTypeNotIsolated);
+    if (parametersUnsafe != null) {
+      info.parameterAction.execute(parametersUnsafe);
+    }
+
+
+    Isolatable<WorkParameters> paramIsol = serviceRegistry.get(IsolatableFactory.class).isolate(parametersUnsafe);
+
+    IsolatableSerializerRegistry isolatableSerializerRegistry = this.serviceRegistry.get(IsolatableSerializerRegistry.class);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    Serializer serializer = isolatableSerializerRegistry.build(paramIsol.getClass());
+    try {
+      serializer.write(new OutputStreamBackedEncoder(bos), paramIsol);
+    } catch (Exception e) {
+      passThrowableAlong(e);
+    }
+
+    String prefix = parametersUnsafe instanceof CachedIsolatedWorkQueue.WorkQueueParameters ? ((CachedIsolatedWorkQueue.WorkQueueParameters) parametersUnsafe)
+            .getPrefix().getOrElse("[WA]") : "[WA]";
+
+    String uniqueId = parametersUnsafe instanceof CachedIsolatedWorkQueue.WorkQueueParameters ? ((CachedIsolatedWorkQueue.WorkQueueParameters) parametersUnsafe).getStatsUniqueName().getOrElse("?") : "?";
+
+    executeInClassloader(() -> {
+
+              try {
+                Isolatable<?> params = isolatableSerializerRegistry.readIsolatable(new InputStreamBackedDecoder(
+                        new ByteArrayInputStream(bos.toByteArray())));
+
+                // finished params init
+
+                // Create the WorkAction itself
+
+                // instantiate within the new classloader
+
+                // prepare instantiator to set parameters
+
+                Class<? extends WorkParameters> paramTypeIsolated =
+                        (Class<? extends WorkParameters>) Thread.currentThread().getContextClassLoader()
+                                .loadClass(parameterTypeNotIsolated.getName());
+
+                ServiceLookup instantiationServices =
+                        isolationScheme.servicesForImplementation(params.coerce(paramTypeIsolated), info.services,
+                                Collections.emptySet(), aClass -> false);
+
+                Instantiator instantiator = info.instantiatorFactory.inject(instantiationServices);
+
+                // Load a fresh instance of this class
+                Class<? extends WorkAction> c =
+                        (Class<? extends WorkAction>) Thread.currentThread().getContextClassLoader()
+                                .loadClass(info.workActionClass.getName());
+                WorkAction<?> action = instantiator.newInstance(c);
+                action.execute();
+              } catch (Exception e) {
+                passThrowableAlong(e);
+              }
+            }, prefix, uniqueId,
+            f -> f.minus(info.classPath).getFiles().isEmpty() && info.classPath.minus(f).getFiles()
+                    .isEmpty(), // check if the difference between the classpaths is empty
+            () -> info.classPath);
+  }
+
+  /**
+   * Loads a class and runs a given method in an isolated class loader
+   * Requires the class and method name as Strings,
+   * such that we do not load them from an existing parent classloader
+   *
+   * @param prefix    Prefixes this string via a {@link PrefixStream}
+   * @param uniqueId  Uniqueid for tracking via the stats
+   * @param predicate allows to check for additional elements, such as classpath
+   * @param supplier  allows to set the additional arguments for a new loader
+   */
+  protected void executeInClassloader(Runnable runnable, @Nullable String prefix,
+                                      @Nullable String uniqueId,
+                                      Predicate<FileCollection> predicate, Supplier<FileCollection> supplier) {
+    final Thread currentThread = Thread.currentThread();
+    ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+    UUID uuid = null;
+    try (IIsolationData isolationData = getLoader(predicate, supplier, uniqueId)) {
+      uuid = isolationData.getUUID();
+      currentThread.setContextClassLoader(isolationData.getClassLoader());
+
+      // set the prefix for the printing
+      if (prefix != null) {
+        redirectStream(getOrReplaceErr(), prefix);
+        redirectStream(getOrReplaceOut(), prefix);
+      }
+      stats.track(CachedIsolationStats.EventKind.START, uuid, maximumLoadersFromConfig, this.internalRunners, uniqueId);
+
+      // Use doPrivileged() to avoid spawned threads inheriting the
+      // AccessControlContext of the current thread.
+      // No privileged actions are actually performed.
+      // Reason: among the ProtectionDomains of the thread will otherwise be a
+      // reference to the Isolated and/or children Groovy Classloader,
+      // preventing the GC from reclaiming said Classloader with all its
+      // loaded objects
+      AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+        try {
+          // Prepare for the cleanup after <a href="https://bugs.openjdk.org/browse/JDK-8078641">JDK-8078641</a>
+          // Load the MethodHandleImpl class into the isolated classloader
+          // as the GroovyInterpreter will otherwise load it within its
+          // ClassLoaders, resulting in it being not accessible to this outer CL
+          isolationData.getClassLoader().loadClass("java.lang.invoke.MethodHandleImpl");
+        } catch (ReflectiveOperationException ignored) {
+        }
+        runnable.run();
+        return null;
+        // Continue with the modified AccessControlContext
+      }, new AccessControlContext(NO_DOMAINS_ACCESS_CONTROL_CONTEXT, combiner));
+    } finally {
+      if (prefix != null) {
+        // Reset this threads prefix printers
+        getOrReplaceErr().reset();
+        getOrReplaceOut().reset();
+      }
+      currentThread.setContextClassLoader(originalClassLoader);
+      stats.track(CachedIsolationStats.EventKind.DONE, uuid, maximumLoadersFromConfig, this.internalRunners);
+    }
+  }
+
+  /**
+   * A {@link DomainCombiner} which removes inner class loaders from a Threads
+   * {@link AccessControlContext}
+   * <p>
+   * The {@link #isClassLoaderOrChild(ClassLoader)} method filters said
+   * child class loaders.
+   */
+  protected DomainCombiner combiner = (currentDomains, assignedDomains) -> {
+    // The assigned Domains should be equivalent to NO_DOMAINS or null,
+    // but groovy uses AccessController.doPrivileged itself, causing
+    // the UpdateCheckerRunnable to be assigned its current domains
+    // We thus skip them, as otherwise the context loader leaks
+    final List<ProtectionDomain> combinedWithoutIsolated = new ArrayList<>();
+    for (ProtectionDomain protectionDomain : currentDomains) {
+      if (protectionDomain.getClassLoader() == null || !isClassLoaderOrChild(
+              protectionDomain.getClassLoader())) {
+        combinedWithoutIsolated.add(protectionDomain);
+      }
+    }
+    return combinedWithoutIsolated.toArray(new ProtectionDomain[0]);
+  };
+
+  /**
+   * @return true if said class loader should not be included in an {@link AccessControlContext}
+   */
+  protected boolean isClassLoaderOrChild(ClassLoader classloader) {
+    if (classloader == null) {
+      return false;
+    }
+    // Note: We are unable to compare using the class object due to classloaders
+    return classloader.getClass().getName().equals(IsolatedURLClassLoader.class.getName())
+            || classloader.getClass().getName().equals("groovy.lang.GroovyClassLoader$InnerLoader");
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <E extends Throwable> void passThrowableAlong(Throwable e) throws E {
+    throw (E) e;
+  }
+
+  /**
+   * See {@link PrintStreamThreadProxy}
+   *
+   * @return the wrapped error stream
+   */
+  protected synchronized PrintStreamThreadProxy getOrReplaceErr() {
+    synchronized (System.err) { // make sure we lock onto System.err too
+      if (System.err instanceof PrintStreamThreadProxy) {
+        return (PrintStreamThreadProxy) System.err;
+      }
+      System.setErr(new PrintStreamThreadProxy(System.err));
+      return (PrintStreamThreadProxy) System.err;
+    }
+  }
+
+  /**
+   * See {@link PrintStreamThreadProxy}
+   *
+   * @return the wrapped error stream
+   */
+  protected synchronized PrintStreamThreadProxy getOrReplaceOut() {
+    synchronized (System.out) { // make sure we lock onto System.out too
+      if (System.out instanceof PrintStreamThreadProxy) {
+        return (PrintStreamThreadProxy) System.out;
+      }
+      System.setOut(new PrintStreamThreadProxy(System.out));
+      return (PrintStreamThreadProxy) System.out;
+    }
+  }
+
+  /**
+   * Redirect a print stream into a prefix stream.
+   * ThreadLocalPrintStream is used to support multiple threads
+   */
+  protected void redirectStream(PrintStreamThreadProxy ps, String prefix) {
+    ps.setRedirect(new PrefixStream(ps.getOriginal(), prefix));
+  }
+
+  public <T extends WorkParameters> void register(UUID uuid,
+                                                  Class<? extends WorkAction<T>> workActionClass, Action<? super T> parameterAction,
+                                                  InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry,
+                                                  FileCollection classPath) {
+
+    this.taskInfoMap.put(uuid,
+            new CachedQueueService.ActualTaskInfo(workActionClass, parameterAction,
+                    Objects.requireNonNull(instantiatorFactory, "instantiatorFactory"),
+                    Objects.requireNonNull(serviceRegistry, "serviceRegistry"), classPath));
+  }
+
+  public static class ActualTaskInfo<T extends WorkParameters> {
+
+    final Class<? extends WorkAction<T>> workActionClass;
+    final Action<? super WorkParameters> parameterAction;
+    public InstantiatorFactory instantiatorFactory;
+    public ServiceRegistry services;
+    public FileCollection classPath;
+
+    public ActualTaskInfo(Class<? extends WorkAction<T>> workActionClass,
+                          Action<? super WorkParameters> parameterAction, InstantiatorFactory instantiatorFactory,
+                          ServiceRegistry serviceRegistry, FileCollection classPath) {
+      this.workActionClass = workActionClass;
+      this.parameterAction = parameterAction;
+      this.instantiatorFactory = instantiatorFactory;
+      this.services = serviceRegistry;
+      this.classPath = classPath;
+    }
+  }
+
+  protected static class IsolationData implements IIsolationData {
+
+    protected ClassLoader classLoader;
+
+    protected boolean running;
+
+    protected long lastRun = System.currentTimeMillis();
+
+    protected FileCollection extraData;
+
+    protected final UUID uuid = UUID.randomUUID();
+
+    @Override
+    public ClassLoader getClassLoader() {
+      return classLoader;
+    }
+
+    @Override
+    public boolean isRunning() {
+      return this.running;
+    }
+
+    @Override
+    public void setRunning(boolean r) {
+      this.running = r;
+    }
+
+    @Override
+    public FileCollection getExtraData() {
+      return extraData;
+    }
+
+    @Override
+    public long getLastRun() {
+      return lastRun;
+    }
+
+    @Override
+    public UUID getUUID() {
+      return uuid;
+    }
+
+    @Override
+    public void cleanUp() {
+      this.classLoader = null;
+      this.extraData = null;
+    }
+
+    @Override
+    public void close() {
+      this.running = false;
+      this.lastRun = System.currentTimeMillis();
+    }
+  }
+
+  protected interface IIsolationData extends AutoCloseable {
+
+    ClassLoader getClassLoader();
+
+    boolean isRunning();
+
+    void setRunning(boolean r);
+
+    FileCollection getExtraData();
+
+    void cleanUp();
+
+    long getLastRun();
+
+    UUID getUUID();
+
+    @Override
+    void close();
+  }
+
+  protected static int guessInitialMaxParallel() {
+    // We generously estimate 500MB of memory usage per concurrent worker execution
+    // This memory footprint includes the runtime object, as well as overhead for loading classes, the jars
+    // within the classpath, etc.
+    long leftOverMemory = Runtime.getRuntime().maxMemory() - Runtime.getRuntime().totalMemory();
+    // We always allow 4 parallel workers by default (use CONCURRENT_MC_PROPERTY to increase this value)
+    return (int) Math.max(4, leftOverMemory / 500000000d);
+  }
+
+  @Override
+  public void started(BuildOperationDescriptor buildOperationDescriptor, OperationStartEvent operationStartEvent) {
+    // noop
+  }
+
+  @Override
+  public void progress(OperationIdentifier operationIdentifier, OperationProgressEvent operationProgressEvent) {
+    // noop
+  }
+
+  @Override
+  public void finished(BuildOperationDescriptor buildOperationDescriptor, OperationFinishEvent operationFinishEvent) {
+    if (buildOperationDescriptor.getDetails() instanceof RunRootBuildWorkBuildOperationType.Details) {
+      stats.track(CachedIsolationStats.EventKind.BUILT_DONE, null, maximumLoadersFromConfig, this.internalRunners);
+      this.markForErasure();
+      // Note: we could/should push the stats to somewhere?
+    }
+  }
+
+  public String getStats() {
+    return stats.asJson(new Gson());
+  }
+
+  /**
+   * Mark all internal runers as ready to be unloaded
+   */
+  public void markForErasure() {
+    logger.debug("Marking forErasure");
+    this.internalRunners.forEach(r -> ((IsolationData) r).lastRun = 0);
+  }
+
+
+  /**
+   * Construc
+   *
+   * @param workerExecutor        the worker executor to use
+   * @param extraClasspathElement the classpath elements to use
+   * @return a new {@link WorkQueue}
+   */
+  public WorkQueue newWorkQueue(WorkerExecutor workerExecutor, FileCollection extraClasspathElement) {
+    return new CachedIsolatedWorkQueue(workerExecutor.noIsolation(),
+            serviceRegistry.get(InstantiatorFactory.class),
+            Objects.requireNonNull(serviceRegistry, "serviceRegistry"),
+            this.providerSelf,
+            extraClasspathElement);
+  }
+}

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedQueueServicePlugin.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedQueueServicePlugin.java
@@ -1,0 +1,41 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.gradle.queue;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskProvider;
+
+/**
+ * Base plugin managing the cached isolation service
+ */
+public class CachedQueueServicePlugin implements Plugin<Project> {
+  @Override
+  public void apply(@NonNull Project project) {
+    // Register the service, if needed
+    Provider<CachedQueueService> sp = project.getGradle().getSharedServices().registerIfAbsent(CachedQueueService.NAME, CachedQueueService.class, spec -> {
+    });
+    if (project == project.getRootProject()) {
+      // initialize the service but only if it is the root project
+      sp.get().init(project.getGradle());
+
+      // Register an optional reporting task
+      TaskProvider<ReportCachedQueueServiceTask> reportTask = project.getTasks().register("reportCachedQueueService", ReportCachedQueueServiceTask.class, spec -> {
+        spec.mustRunAfter(project.getTasks().withType(ICachedQueueTask.class));
+        spec.getSharedQueueService().set(sp);
+      });
+      project.getTasks().withType(ICachedQueueTask.class).configureEach(task -> {
+        task.finalizedBy(reportTask);
+      });
+    }
+
+
+    // And configure all tasks with the ICachedQueueTask interface to access this service
+
+    project.getTasks().withType(ICachedQueueTask.class).configureEach(task -> {
+      task.getSharedQueueService().set(sp);
+    });
+  }
+
+}

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/queue/ICachedQueueTask.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/queue/ICachedQueueTask.java
@@ -1,0 +1,15 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.gradle.queue;
+
+import org.gradle.api.Task;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Internal;
+
+/**
+ * A task with access to a cached queue service.
+ * Automatically managed via the {@link CachedQueueServicePlugin}
+ */
+public interface ICachedQueueTask extends Task {
+  @Internal
+  Property<CachedQueueService> getSharedQueueService();
+}

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/queue/ReportCachedQueueServiceTask.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/queue/ReportCachedQueueServiceTask.java
@@ -1,0 +1,35 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.gradle.queue;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+
+/**
+ * Reports the (current) state of the cachedQueueService stats in json format
+ */
+public abstract class ReportCachedQueueServiceTask extends DefaultTask {
+
+  @OutputFile
+  abstract public RegularFileProperty getOutputFile();
+
+  public ReportCachedQueueServiceTask() {
+    getOutputFile().convention(() -> getProject().getLayout().getBuildDirectory().file("cachedqueuestats.json").get().getAsFile());
+  }
+
+  @Internal
+  public abstract Property<CachedQueueService> getSharedQueueService();
+
+  @TaskAction
+  public void execute() throws IOException {
+    Files.write(getOutputFile().get().getAsFile().toPath(),
+            Collections.singletonList(getSharedQueueService().get().getStats()));
+  }
+}

--- a/se-commons-gradle/src/test/java/IsolatedWorkerQueueTest.java
+++ b/se-commons-gradle/src/test/java/IsolatedWorkerQueueTest.java
@@ -1,0 +1,138 @@
+/* (c) https://github.com/MontiCore/monticore */
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This test checks the various kinds of isolations between workers:
+ * - how many times a class is loaded
+ * - how it reacts with static side effects
+ *
+ */
+public class IsolatedWorkerQueueTest {
+
+  @Test
+  public void testNoIsolation() throws Exception {
+    File projectDir = new File("build/functionalTest/noi");
+    projectDir.mkdirs();
+    new File(projectDir, "settings.gradle").createNewFile();
+    write(new File(projectDir, "build.gradle"),
+            "    plugins {\n" + "        id 'se.rwth.example' \n" + "    } \n"
+                    + "    import se.rwth.example.ExampleTask \n"
+                    + "    import se.rwth.example.ExampleTask.WorkerKind \n"
+                    + "    tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.NO_ISOLATION} ) \n"
+                    + "    tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.NO_ISOLATION} ) \n"
+                    + "    B.dependsOn(A)\n" + "    \n");
+
+    BuildResult result = GradleRunner.create().withProjectDir(projectDir).withPluginClasspath()
+            .withArguments("A", "B").build();
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":A").getOutcome());
+    assertEquals(TaskOutcome.SUCCESS, result.task(":B").getOutcome());
+    System.out.println(result.getOutput());
+    List<String> o = getActionOutputs(result);
+    assertEquals(1, getInitCount(result));
+    assertEquals("pre:  -+-+> A1", o.get(0));
+    assertEquals("pre: A1 -+-+> A2", o.get(1));
+    assertEquals("pre: A1A2 -+-+> B1", o.get(2));
+    assertEquals("pre: A1A2B1 -+-+> B2", o.get(3));
+  }
+
+
+  @Test
+  public void testCLIsolation() throws Exception {
+    File projectDir = new File("build/functionalTest/cl");
+    projectDir.mkdirs();
+    new File(projectDir, "settings.gradle").createNewFile();
+    write(new File(projectDir, "build.gradle"),
+            "    plugins {\n" + "        id 'se.rwth.example' \n" + "    } \n"
+                    + "    import se.rwth.example.ExampleTask \n"
+                    + "    import se.rwth.example.ExampleTask.WorkerKind \n"
+                    + "    tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.CL} ) \n"
+                    + "    tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.CL} ) \n"
+                    + "    B.dependsOn(A)\n" + "    \n");
+
+    BuildResult result = GradleRunner.create().withProjectDir(projectDir).withPluginClasspath()
+            .withArguments("A", "B").build();
+
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":A").getOutcome());
+    assertEquals(TaskOutcome.SUCCESS, result.task(":B").getOutcome());
+    System.out.println(result.getOutput());
+    List<String> o = getActionOutputs(result);
+    assertEquals(4, getInitCount(result));
+    assertEquals("pre:  -+-+> A1", o.get(0));
+    assertEquals("pre:  -+-+> A2", o.get(1));
+    assertEquals("pre:  -+-+> B1", o.get(2));
+    assertEquals("pre:  -+-+> B2", o.get(3));
+  }
+
+
+  @ParameterizedTest
+  @ValueSource(strings = {"7.4.2", "7.6.4", "8.0.1", "8.7"})
+  public void testSharedIsolation(String version) throws Exception {
+    File projectDir = new File("build/functionalTest/shared/" + version);
+    projectDir.mkdirs();
+    new File(projectDir, "settings.gradle").createNewFile();
+    write(new File(projectDir, "build.gradle"),
+            "    plugins {\n" + "        id 'se.rwth.example' \n" + "    } \n"
+                    + "    import se.rwth.example.ExampleTask \n"
+                    + "    import se.rwth.example.ExampleTask.WorkerKind \n"
+                    + "    tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.SHARED} ) \n"
+                    + "    tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.SHARED} ) \n"
+                    + "    B.dependsOn(A)\n" + "    \n");
+
+    BuildResult result = GradleRunner.create()
+            .withGradleVersion(version)
+            .withProjectDir(projectDir).withPluginClasspath()
+            .withArguments("A", "B", "--stacktrace").build();
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":A").getOutcome());
+    assertEquals(TaskOutcome.SUCCESS, result.task(":B").getOutcome());
+    System.out.println(result.getOutput());
+    List<String> o = getActionOutputs(result);
+    assertEquals(2, getInitCount(result));
+    assertEquals("[A1]pre:  -+-+> A1", o.get(0));
+    assertEquals("[A2]pre:  -+-+> A2", o.get(1));
+    // assert that B1 and B2 use re-used
+    Assertions.assertTrue(o.get(2).matches("\\[B.]pre: A. -\\+-\\+> B1"), o.get(2));
+    Assertions.assertTrue(o.get(3).matches("\\[B.]pre: A. -\\+-\\+> B2"), o.get(3));
+
+    String json = result.getOutput().substring(result.getOutput().indexOf("Stats[[") + "Stats[[".length(), result.getOutput().indexOf("]]Stats"));
+
+    Assertions.assertEquals(2, StringUtils.countMatches(json, "\"REUSE\""));
+    Assertions.assertEquals(2, StringUtils.countMatches(json, "\"CREATE\""));
+    Assertions.assertEquals(4, StringUtils.countMatches(json, "\"START\""));
+    Assertions.assertEquals(4, StringUtils.countMatches(json, "\"DONE\""));
+  }
+
+
+  protected void write(File file, String content) throws IOException {
+    Files.write(file.toPath(), content.getBytes());
+  }
+
+  protected List<String> getActionOutputs(BuildResult result) {
+    return Arrays.stream(result.getOutput().split(System.lineSeparator()))
+            .filter(l -> l.contains("pre:")).map(l -> l.replace(System.lineSeparator(), ""))
+            .collect(Collectors.toList());
+  }
+
+  protected long getInitCount(BuildResult result) {
+    return Arrays.stream(result.getOutput().split(System.lineSeparator()))
+            .filter(l -> l.contains("INIT TestAction")).count();
+  }
+}

--- a/se-commons-gradle/src/testPlugin/java/se/rwth/example/ExampleTask.java
+++ b/se-commons-gradle/src/testPlugin/java/se/rwth/example/ExampleTask.java
@@ -1,0 +1,70 @@
+/* (c) https://github.com/MontiCore/monticore */
+package se.rwth.example;
+
+import de.monticore.gradle.queue.ICachedQueueTask;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.WorkQueue;
+import org.gradle.workers.WorkerExecutor;
+
+import javax.inject.Inject;
+
+/**
+ * A Task scheduling its action using the selected workQueue
+ */
+public abstract class ExampleTask extends DefaultTask implements ICachedQueueTask {
+
+  @Inject
+  abstract public WorkerExecutor getWorkerExecutor();
+
+  @Input
+  abstract public ListProperty<String> getTaskNames();
+
+  @Input
+  @Optional
+  abstract public Property<Integer> getWaitSeconds();
+
+  @Input
+  @Optional
+  abstract public Property<WorkerKind> getWorkerKind();
+
+  @TaskAction
+  public void execute() {
+    WorkQueue queue;
+    switch (getWorkerKind().getOrElse(WorkerKind.NO_ISOLATION)) {
+      case NO_ISOLATION:
+        queue = getWorkerExecutor().noIsolation();
+        break;
+      case CL:
+        queue = getWorkerExecutor().classLoaderIsolation();
+        break;
+      case SHARED:
+        queue = getSharedQueueService().get().newWorkQueue(getWorkerExecutor(), getProject().getObjects().fileCollection());
+        break;
+      default:
+        throw new IllegalStateException("Unknown worker kind: " + getWorkerKind().get());
+    }
+
+    int waitSeconds = getWaitSeconds().getOrElse(1);
+    for (final String name : getTaskNames().get()) {
+      final int secondForThisRun = waitSeconds += 2;
+      queue.submit(TestAction.class, task -> {
+        task.getWaitSeconds().set(secondForThisRun);
+        task.getName().set(name);
+        task.getPrefix().set("[" + name + "]"); // and set the prefix
+        task.getStatsUniqueName().set(name);
+      });
+    }
+
+  }
+
+  public enum WorkerKind {
+    NO_ISOLATION, // no isolation
+    CL, // classloader isolation
+    SHARED // shared isolation
+  }
+}

--- a/se-commons-gradle/src/testPlugin/java/se/rwth/example/ReportStatsTask.java
+++ b/se-commons-gradle/src/testPlugin/java/se/rwth/example/ReportStatsTask.java
@@ -1,0 +1,18 @@
+/* (c) https://github.com/MontiCore/monticore */
+package se.rwth.example;
+
+import de.monticore.gradle.queue.ICachedQueueTask;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * Example task that reports its state to std::err
+ */
+public abstract class ReportStatsTask extends DefaultTask implements ICachedQueueTask {
+
+  @TaskAction
+  public void execute() {
+    System.err.println("Stats[[" + getSharedQueueService().get().getStats() + "]]Stats");
+  }
+
+}

--- a/se-commons-gradle/src/testPlugin/java/se/rwth/example/TestAction.java
+++ b/se-commons-gradle/src/testPlugin/java/se/rwth/example/TestAction.java
@@ -1,0 +1,33 @@
+/* (c) https://github.com/MontiCore/monticore */
+
+package se.rwth.example;
+
+import org.gradle.workers.WorkAction;
+
+/**
+ * An example workaction, testing the various queues
+ */
+public abstract class TestAction implements WorkAction<TestParams> {
+
+  // A static state
+  public static StringBuilder sb = new StringBuilder();
+
+  static {
+    // Report classloading
+    System.out.println("INIT TestAction"); // We expect this message in our test
+  }
+
+  @Override
+  public void execute() {
+    try {
+      System.out.println("before wait " + getParameters().getName().get());
+      Thread.sleep(1000L * getParameters().getWaitSeconds().get());
+      System.out.println("pre: " + sb.toString() + " -+-+> " + getParameters().getName().get()); // we expect this message in our test
+      sb.append(getParameters().getName().get());
+      System.out.println("done " + getParameters().getName().get());
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+}

--- a/se-commons-gradle/src/testPlugin/java/se/rwth/example/TestParams.java
+++ b/se-commons-gradle/src/testPlugin/java/se/rwth/example/TestParams.java
@@ -1,0 +1,10 @@
+/* (c) https://github.com/MontiCore/monticore */
+package se.rwth.example;
+
+import de.monticore.gradle.queue.CachedIsolatedWorkQueue;
+import org.gradle.api.provider.Property;
+
+public interface TestParams extends CachedIsolatedWorkQueue.WorkQueueParameters {
+  Property<String> getName();
+  Property<Integer> getWaitSeconds();
+}

--- a/se-commons-gradle/src/testPlugin/java/se/rwth/example/TestPlugin.java
+++ b/se-commons-gradle/src/testPlugin/java/se/rwth/example/TestPlugin.java
@@ -1,0 +1,25 @@
+/* (c) https://github.com/MontiCore/monticore */
+
+package se.rwth.example;
+
+import de.monticore.gradle.queue.CachedQueueServicePlugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskProvider;
+
+public class TestPlugin implements Plugin<Project> {
+
+  @Override
+  public void apply(@NonNull Project project) {
+    // Register the service
+    project.getPluginManager().apply(CachedQueueServicePlugin.class);
+
+    TaskProvider<ReportStatsTask> reportStatsTask = project.getTasks().register("reportStats", ReportStatsTask.class, task -> {
+    });
+
+    project.getTasks().withType(ExampleTask.class).configureEach(task -> {
+      task.finalizedBy(reportStatsTask);
+    });
+  }
+}

--- a/se-commons-gradle/src/testPlugin/resources/META-INF/gradle-plugins/se.rwth.example.properties
+++ b/se-commons-gradle/src/testPlugin/resources/META-INF/gradle-plugins/se.rwth.example.properties
@@ -1,0 +1,1 @@
+implementation-class=se.rwth.example.TestPlugin


### PR DESCRIPTION
* incrementalSymbolPath: ignore timestamps, only check against file content
* use relative file paths when starting tasks
* Add WorkerQueue implementation for CachedIsolation, including stats

An example of a small test project:
<img width="2201" height="395" alt="CachedIsolationWorkQueueStats" src="https://github.com/user-attachments/assets/f68093d7-a22f-475d-93e6-8fa9b0026bf1" />
