### PR TITLE
Provide SharedToolAction and MainClass Property

### DIFF
--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/CommonMCTask.java
@@ -390,6 +390,7 @@ public abstract class CommonMCTask extends DefaultTask {
       // In normal mode, run in a workQue. This ensures isolation & parallelization
       workQueue.submit(getToolAction(), param -> {
         param.getArgs().set(args);
+        param.getMainClass().set(getMainClass());
         param.getProgressName().set(progressName);
         param.getPrefix().set("[" + progressName + "]");
         // A unique name for the stats reporter, etc.
@@ -420,8 +421,22 @@ public abstract class CommonMCTask extends DefaultTask {
     throw new IllegalStateException("No tool invoker present, workQueueDebug is not supported!");
   }
 
+  /**
+   * @return the main class (to be called by the SharedToolAction)
+   */
+  @Input
+  @Optional
+  public abstract Property<String> getMainClass();
+
+  /**
+   * By default, the SharedToolAction is used.
+   * It uses the getMainClass property
+   * @return the tool action to pass to the workqueue
+   */
   @Internal
-  protected abstract Class<? extends AToolAction> getToolAction();
+  protected Class<? extends AToolAction> getToolAction() {
+    return SharedToolAction.class;
+  }
 
   /**
    * Set of additional input directories which are used during the inc check

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/SharedToolAction.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/SharedToolAction.java
@@ -1,0 +1,38 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.gradle.common;
+
+import de.se_rwth.commons.logging.Log;
+import java.util.Arrays;
+
+/**
+ * Action to represent the invocation of a tool.
+ * Uses the mainClass property to call (mainClass)#gradleMain.
+ * This avoids defining your own ToolInvoker
+ */
+public abstract class SharedToolAction extends AToolAction {
+
+  protected void doRun(String[] args) {
+    if (!getParameters().getMainClass().isPresent())
+      throw new IllegalStateException("MainClass property is required");
+    GradleLog.init();
+    Log.info("Starting " + getParameters().getMainClass().get() +
+             ": \n\t  java -jar <ToolJar>.jar " + Arrays.toString(args),
+            getParameters().getMainClass().get());
+    try {
+      Class<?> mainClass = Class.forName(getParameters().getMainClass().get());
+      mainClass.getMethod("gradleMain", String[].class).invoke(null, (Object)args);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Failed to find main class " + getParameters().getMainClass().get());
+    } catch (NoSuchMethodException error) {
+      // Special case: method does not exist
+      throw new IllegalStateException("The main class " + getParameters().getMainClass() + " does not provide a #gradleMain method");
+    } catch (ReflectiveOperationException e) {
+      // pass upwards
+      sneakyThrow(e.getCause());
+    }
+  }
+
+  public static <E extends Throwable> void sneakyThrow(Throwable e) throws E {
+    throw (E) e;
+  }
+}

--- a/se-commons-gradle/src/main/java/de/monticore/gradle/common/ToolArgActionParameter.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/common/ToolArgActionParameter.java
@@ -31,4 +31,9 @@ public interface ToolArgActionParameter extends CachedIsolatedWorkQueue.WorkQueu
      * See {@link ProgressLoggerService}
      */
     Property<ProgressLoggerService> getProgressLogger();
+
+    /**
+     * @return MainClass that should be called
+     */
+    Property<String> getMainClass();
 }


### PR DESCRIPTION
Instead of adding the Action & Tool Invoker class, the `mainClass` property can be used (e.g. via the task constructor) to specify the main class.