### PR TITLE
Support Gradle 9.6.x

### DIFF
--- a/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedQueueService.java
+++ b/se-commons-gradle/src/main/java/de/monticore/gradle/queue/CachedQueueService.java
@@ -12,6 +12,7 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ValueSourceParameters;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceRegistry;
@@ -41,7 +42,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -135,14 +138,13 @@ public abstract class CachedQueueService
    */
   protected Map<UUID, ActualTaskInfo<?>> taskInfoMap = new ConcurrentHashMap<>();
 
-  protected final IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme =
-          new IsolationScheme<>(Cast.uncheckedCast(WorkAction.class), WorkParameters.class,
-                  WorkParameters.None.class);
+  protected final IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme;
 
   public CachedQueueService() {
     this.maximumLoadersFromConfig = guessInitialMaxParallel();
     logger.debug("Starting with a maximum count of {}", maximumLoadersFromConfig);
     this.semaphore = new Semaphore(maximumLoadersFromConfig);
+    this.isolationScheme = createNewIsolationScheme();
   }
 
   public synchronized void setMaxConcurrentMC(int maxParallelMC) {
@@ -693,6 +695,32 @@ public abstract class CachedQueueService
     // We always allow 2 parallel workers by default (use CONCURRENT_MC_PROPERTY to increase/decrease this value)
     // In the future: Move this limit to a per-workqueue basis - as in "do I have 150MB available?"
     return (int) Math.max(2, leftOverMemory / (estimated_memory_usage_in_mb*1000*1000));
+  }
+  
+  protected static IsolationScheme<WorkAction<?>, WorkParameters> createNewIsolationScheme() {
+    // Gradle 9.6.0 and 9.6.1 use a modified constructor signature with an additional parameter.
+    // However, it is reverted for 9.7.0.
+    try {
+      try {
+        Constructor<?> constructor =
+            IsolationScheme.class.getConstructor(Class.class, Class.class, Class.class);
+        return Cast.uncheckedCast(constructor.newInstance(WorkAction.class, WorkParameters.class,
+            WorkParameters.None.class));
+      }
+      catch (NoSuchMethodException ex) {
+        Constructor<?> constructor =
+            IsolationScheme.class.getConstructor(Class.class, Class.class, Class.class,
+                Object.class);
+        return Cast.uncheckedCast(constructor.newInstance(WorkAction.class, WorkParameters.class,
+            WorkParameters.None.class, ValueSourceParameters.None.class));
+      }
+    }
+    catch (NoSuchMethodException ex) {
+      throw new RuntimeException("Gradle version currently unsupported", ex);
+    }
+    catch (InstantiationException | IllegalAccessException | InvocationTargetException ex) {
+      throw new RuntimeException("Failed to create IsolationScheme", ex);
+    }
   }
 
   @Override

--- a/se-commons-gradle/src/test/java/IsolatedWorkerQueueTest.java
+++ b/se-commons-gradle/src/test/java/IsolatedWorkerQueueTest.java
@@ -93,7 +93,7 @@ public class IsolatedWorkerQueueTest {
 
 
   @ParameterizedTest
-  @ValueSource(strings = {"8.5", "8.7", "8.14", "9.3.1","9.5.1"})
+  @ValueSource(strings = {"8.5", "8.7", "8.14", "9.3.1","9.5.1", "9.6.1"})
   public void testSharedIsolation(String version) throws Exception {
     File projectDir = new File("build/functionalTest/shared/" + version);
     projectDir.mkdirs();

--- a/se-commons-gradle/src/test/java/IsolatedWorkerQueueTest.java
+++ b/se-commons-gradle/src/test/java/IsolatedWorkerQueueTest.java
@@ -4,7 +4,6 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -16,7 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This test checks the various kinds of isolations between workers:
@@ -32,12 +31,17 @@ public class IsolatedWorkerQueueTest {
     projectDir.mkdirs();
     new File(projectDir, "settings.gradle").createNewFile();
     write(new File(projectDir, "build.gradle"),
-            "    plugins {\n" + "        id 'se.rwth.example' \n" + "    } \n"
-                    + "    import se.rwth.example.ExampleTask \n"
-                    + "    import se.rwth.example.ExampleTask.WorkerKind \n"
-                    + "    tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.NO_ISOLATION} ) \n"
-                    + "    tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.NO_ISOLATION} ) \n"
-                    + "    B.dependsOn(A)\n" + "    \n");
+            """
+            plugins {
+              id 'se.rwth.example'
+            }
+            import se.rwth.example.ExampleTask
+            import se.rwth.example.ExampleTask.WorkerKind
+            tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.NO_ISOLATION} )
+            tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.NO_ISOLATION} )
+            B.dependsOn(A)
+            """
+    );
 
     BuildResult result = GradleRunner.create().withProjectDir(projectDir).withPluginClasspath()
             .withArguments("A", "B").build();
@@ -60,12 +64,17 @@ public class IsolatedWorkerQueueTest {
     projectDir.mkdirs();
     new File(projectDir, "settings.gradle").createNewFile();
     write(new File(projectDir, "build.gradle"),
-            "    plugins {\n" + "        id 'se.rwth.example' \n" + "    } \n"
-                    + "    import se.rwth.example.ExampleTask \n"
-                    + "    import se.rwth.example.ExampleTask.WorkerKind \n"
-                    + "    tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.CL} ) \n"
-                    + "    tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.CL} ) \n"
-                    + "    B.dependsOn(A)\n" + "    \n");
+            """
+            plugins {
+              id 'se.rwth.example'
+            }
+            import se.rwth.example.ExampleTask
+            import se.rwth.example.ExampleTask.WorkerKind
+            tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.CL} )
+            tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.CL} )
+            B.dependsOn(A)
+            """
+    );
 
     BuildResult result = GradleRunner.create().withProjectDir(projectDir).withPluginClasspath()
             .withArguments("A", "B").build();
@@ -90,12 +99,17 @@ public class IsolatedWorkerQueueTest {
     projectDir.mkdirs();
     new File(projectDir, "settings.gradle").createNewFile();
     write(new File(projectDir, "build.gradle"),
-            "    plugins {\n" + "        id 'se.rwth.example' \n" + "    } \n"
-                    + "    import se.rwth.example.ExampleTask \n"
-                    + "    import se.rwth.example.ExampleTask.WorkerKind \n"
-                    + "    tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.SHARED} ) \n"
-                    + "    tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.SHARED} ) \n"
-                    + "    B.dependsOn(A)\n" + "    \n");
+            """
+            plugins {
+              id 'se.rwth.example'
+            }
+            import se.rwth.example.ExampleTask
+            import se.rwth.example.ExampleTask.WorkerKind
+            tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.SHARED} )
+            tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.SHARED} )
+            B.dependsOn(A)
+            """
+    );
 
     BuildResult result = GradleRunner.create()
             .withGradleVersion(version)
@@ -110,15 +124,15 @@ public class IsolatedWorkerQueueTest {
     assertEquals("[A1]pre:  -+-+> A1", o.get(0));
     assertEquals("[A2]pre:  -+-+> A2", o.get(1));
     // assert that B1 and B2 use re-used
-    Assertions.assertTrue(o.get(2).matches("\\[B.]pre: A. -\\+-\\+> B1"), o.get(2));
-    Assertions.assertTrue(o.get(3).matches("\\[B.]pre: A. -\\+-\\+> B2"), o.get(3));
+    assertTrue(o.get(2).matches("\\[B.]pre: A. -\\+-\\+> B1"), o.get(2));
+    assertTrue(o.get(3).matches("\\[B.]pre: A. -\\+-\\+> B2"), o.get(3));
 
     String json = result.getOutput().substring(result.getOutput().indexOf("Stats[[") + "Stats[[".length(), result.getOutput().indexOf("]]Stats"));
 
-    Assertions.assertEquals(2, StringUtils.countMatches(json, "\"REUSE\""));
-    Assertions.assertEquals(2, StringUtils.countMatches(json, "\"CREATE\""));
-    Assertions.assertEquals(4, StringUtils.countMatches(json, "\"START\""));
-    Assertions.assertEquals(4, StringUtils.countMatches(json, "\"DONE\""));
+    assertEquals(2, StringUtils.countMatches(json, "\"REUSE\""));
+    assertEquals(2, StringUtils.countMatches(json, "\"CREATE\""));
+    assertEquals(4, StringUtils.countMatches(json, "\"START\""));
+    assertEquals(4, StringUtils.countMatches(json, "\"DONE\""));
   }
   
   @Test
@@ -127,14 +141,19 @@ public class IsolatedWorkerQueueTest {
     projectDir.mkdirs();
     new File(projectDir, "settings.gradle").createNewFile();
     write(new File(projectDir, "build.gradle"),
-        "    plugins {\n" + "        id 'se.rwth.example' \n" + "    } \n"
-            + "    import se.rwth.example.ExampleTask \n"
-            + "    import se.rwth.example.ExampleTask.WorkerKind \n"
-            + "    tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.SHARED; t.withTestService = true;} ) \n"
-            + "    tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.SHARED; t.withTestService = true;} ) \n"
-            + "    B.dependsOn(A)\n" + "    \n");
+            """
+            plugins {
+              id 'se.rwth.example'
+            }
+            import se.rwth.example.ExampleTask
+            import se.rwth.example.ExampleTask.WorkerKind
+            tasks.register('A', ExampleTask.class, t -> {t.taskNames.add('A1'); t.taskNames.add('A2'); t.workerKind = WorkerKind.SHARED; t.withTestService = true;} )
+            tasks.register('B', ExampleTask.class, t -> {t.taskNames.add('B1'); t.taskNames.add('B2'); t.waitSeconds = 1; t.workerKind = WorkerKind.SHARED; t.withTestService = true;} )
+            B.dependsOn(A)
+            """
+    );
     
-    Assertions.assertThrows(UnexpectedBuildFailure.class, () -> {
+    assertThrows(UnexpectedBuildFailure.class, () -> {
       BuildResult result = GradleRunner.create()
           .withGradleVersion("7.6.4")
           .withProjectDir(projectDir).withPluginClasspath()

--- a/se-commons-gradle/src/test/java/IsolatedWorkerQueueTest.java
+++ b/se-commons-gradle/src/test/java/IsolatedWorkerQueueTest.java
@@ -155,7 +155,7 @@ public class IsolatedWorkerQueueTest {
     
     assertThrows(UnexpectedBuildFailure.class, () -> {
       BuildResult result = GradleRunner.create()
-          .withGradleVersion("7.6.4")
+          .withGradleVersion("8.14.5")
           .withProjectDir(projectDir).withPluginClasspath()
           .withArguments("A", "B", "--stacktrace").build();
     });


### PR DESCRIPTION
Gradle 9.6.x uses a modified version of the IsolationScheme, breaking CachedQueueService.
This Pull Request tries to fallback to that modified constructor in case it is unable to use the previous constructor.